### PR TITLE
Pass the issuer as an array of strings

### DIFF
--- a/01-Authorization-RS256/server.js
+++ b/01-Authorization-RS256/server.js
@@ -27,7 +27,7 @@ const checkJwt = jwt({
 
   // Validate the audience and the issuer.
   audience: process.env.AUTH0_AUDIENCE,
-  issuer: `https://${process.env.AUTH0_DOMAIN}/`,
+  issuer: [`https://${process.env.AUTH0_DOMAIN}/`],
   algorithms: ['RS256']
 });
 


### PR DESCRIPTION
This will help clarify that multiple issuers can be given to the express-jwt library. 